### PR TITLE
docs: ignore `localhost` while checking links

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost"
+    }
+  ]
+}


### PR DESCRIPTION
**Description**
Bot fails to [validate local links](https://github.com/asyncapi/chatbot/runs/6143292473?check_suite_focus=true).